### PR TITLE
[Documentation] How to run the entire wallet from local node or via npm registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,20 @@ Karlsen Wallet is implemented in TypeScript and can be used server-side
 
 **PLEASE NOTE: This project is under heavy development**
 
+## Installing karlsen-wallet-worker
+
+```
+npm install -g @karlsen/wallet-worker
+```
+
+## Cloning karlsen-wallet-worker
+
+```
+git clone https://github.com/karlsen-network/node-karlsen-wallet-worker
+cd node-karlsen-wallet-worker
+npm install
+```
+
 ## Components
 
 Karlsen Wallet uses the following modules:
@@ -20,7 +34,7 @@ Applications built on top of Karlsen Wallet Framework:
 
 * [karlsen-faucet](https://github.com/karlsen-network/node-karlsen-faucet) - Karlsen faucet website
 * [karlsen-wallet-cli](https://github.com/karlsen-network/node-karlsen-wallet-cli) - command-line wallet
-* [KDX](https://github.com/karlsen-network/node-kdx) - Karlsen desktop wallet
+* [KDX](https://github.com/karlsen-network/karlsen-kdx) - Karlsen desktop wallet
 
 **PLEASE NOTE:** all Karlsen applications and libraries are under heavy
 development.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "@aspectron/flow-logger": ">=1.0.1",
     "@aspectron/web-worker": "^1.0.0",
-    "@karlsen/wallet": "file:../node-karlsen-wallet"
+    "@karlsen/wallet": ">=1.4.26"
   },
   "devDependencies": {
     "@types/node": "^14.14.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@karlsen/wallet-worker",
-  "version": "1.1.25",
+  "version": "1.1.26",
   "description": "Worker (node + browser) wrapping karlsen-wallet",
   "main": "dist/index.js",
   "authors": [


### PR DESCRIPTION
This is a PR series for all the `node-` packages. Instructions on how to run all of them locally to create web wallet service and how to use published versions in `npm registry` have been added. All the `npm` packages are already available at: https://www.npmjs.com/org/karlsen